### PR TITLE
Implement rendez-vous booking form

### DIFF
--- a/src/app/api/rdv/route.ts
+++ b/src/app/api/rdv/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from 'next/server'
+import { cookies } from 'next/headers'
+import { createServerClient } from '@/utils/supabase'
+
+export async function POST(request: Request) {
+  const { name, email, datetime } = await request.json()
+  const cookieStore = cookies()
+  const supabase = createServerClient(cookieStore)
+  const { error } = await supabase
+    .from('rdv')
+    .insert({ name, email, datetime })
+
+  if (error) {
+    console.error('Error inserting rdv:', error)
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+
+  return NextResponse.json({ message: 'ok' })
+}

--- a/src/app/rendez-vous/page.tsx
+++ b/src/app/rendez-vous/page.tsx
@@ -1,0 +1,63 @@
+'use client'
+
+import { useState } from 'react'
+import { Button } from '@/components/ui/button'
+
+export default function RendezVousPage() {
+  const [name, setName] = useState('')
+  const [email, setEmail] = useState('')
+  const [datetime, setDatetime] = useState('')
+  const [submitted, setSubmitted] = useState(false)
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    const res = await fetch('/api/rdv', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name, email, datetime }),
+    })
+    if (res.ok) {
+      setSubmitted(true)
+      setName('')
+      setEmail('')
+      setDatetime('')
+    }
+  }
+
+  return (
+    <div className="max-w-md mx-auto p-6">
+      {submitted ? (
+        <p className="text-green-600 font-semibold">Votre demande a été enregistrée.</p>
+      ) : (
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <input
+            type="text"
+            placeholder="Nom"
+            required
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            className="w-full border border-gray-300 rounded-md p-2"
+          />
+          <input
+            type="email"
+            placeholder="Email"
+            required
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            className="w-full border border-gray-300 rounded-md p-2"
+          />
+          <input
+            type="datetime-local"
+            required
+            value={datetime}
+            onChange={(e) => setDatetime(e.target.value)}
+            className="w-full border border-gray-300 rounded-md p-2"
+          />
+          <Button type="submit" className="w-full">
+            Envoyer
+          </Button>
+        </form>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add API route to save rendez-vous requests in Supabase
- implement booking form page using the new endpoint

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*
- `npm run type-check` *(fails: missing type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_6844e1d3f1a0832497128c34b6775f4e