### PR TITLE
Add candidate dashboard pages

### DIFF
--- a/src/app/dashboard/candidat/invitations/page.tsx
+++ b/src/app/dashboard/candidat/invitations/page.tsx
@@ -1,0 +1,36 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { createBrowserClient } from '@supabase/ssr'
+
+export default function InvitationsPage() {
+  const [invitations, setInvitations] = useState<any[]>([])
+  const supabase = createBrowserClient()
+
+  useEffect(() => {
+    async function fetchInvitations() {
+      const {
+        data: { user },
+      } = await supabase.auth.getUser()
+      if (!user) return
+      const { data } = await supabase.from('invitations').select('*').eq('user_id', user.id)
+      setInvitations(data || [])
+    }
+    fetchInvitations()
+  }, [])
+
+  return (
+    <div className="p-6 space-y-4">
+      <h1 className="text-2xl font-bold">Mes invitations</h1>
+      {invitations.length === 0 ? (
+        <p>Aucune invitation reçue.</p>
+      ) : (
+        <ul className="list-disc pl-6 space-y-1">
+          {invitations.map((inv) => (
+            <li key={inv.id}>{inv.titre || JSON.stringify(inv)}</li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/src/app/dashboard/candidat/offres/page.tsx
+++ b/src/app/dashboard/candidat/offres/page.tsx
@@ -1,0 +1,36 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { createBrowserClient } from '@supabase/ssr'
+
+export default function OffresPage() {
+  const [offres, setOffres] = useState<any[]>([])
+  const supabase = createBrowserClient()
+
+  useEffect(() => {
+    async function fetchOffres() {
+      const {
+        data: { user },
+      } = await supabase.auth.getUser()
+      if (!user) return
+      const { data } = await supabase.from('offres').select('*').eq('user_id', user.id)
+      setOffres(data || [])
+    }
+    fetchOffres()
+  }, [])
+
+  return (
+    <div className="p-6 space-y-4">
+      <h1 className="text-2xl font-bold">Mes offres</h1>
+      {offres.length === 0 ? (
+        <p>Aucune offre pour le moment.</p>
+      ) : (
+        <ul className="list-disc pl-6 space-y-1">
+          {offres.map((offre) => (
+            <li key={offre.id}>{offre.titre || JSON.stringify(offre)}</li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/src/app/dashboard/candidat/page.tsx
+++ b/src/app/dashboard/candidat/page.tsx
@@ -1,0 +1,42 @@
+'use client'
+
+import Link from 'next/link'
+import { useEffect, useState } from 'react'
+import { createBrowserClient } from '@supabase/ssr'
+
+export default function CandidatDashboard() {
+  const [email, setEmail] = useState<string | null>(null)
+  const supabase = createBrowserClient()
+
+  useEffect(() => {
+    async function fetchUser() {
+      const {
+        data: { user },
+      } = await supabase.auth.getUser()
+      setEmail(user?.email ?? null)
+    }
+    fetchUser()
+  }, [])
+
+  return (
+    <div className="p-6 space-y-6">
+      <h1 className="text-2xl font-bold">
+        Bienvenue{email ? `, ${email}` : ''} !
+      </h1>
+      <nav className="flex gap-4">
+        <Link href="/dashboard/candidat/profil" className="text-blue-600 hover:underline">
+          Profil
+        </Link>
+        <Link href="/dashboard/candidat/offres" className="text-blue-600 hover:underline">
+          Offres
+        </Link>
+        <Link href="/dashboard/candidat/stats" className="text-blue-600 hover:underline">
+          Stats
+        </Link>
+        <Link href="/dashboard/candidat/invitations" className="text-blue-600 hover:underline">
+          Invitations
+        </Link>
+      </nav>
+    </div>
+  )
+}

--- a/src/app/dashboard/candidat/profil/page.tsx
+++ b/src/app/dashboard/candidat/profil/page.tsx
@@ -1,0 +1,28 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { createBrowserClient } from '@supabase/ssr'
+
+export default function ProfilPage() {
+  const [profile, setProfile] = useState<any | null>(null)
+  const supabase = createBrowserClient()
+
+  useEffect(() => {
+    async function fetchProfile() {
+      const {
+        data: { user },
+      } = await supabase.auth.getUser()
+      if (!user) return
+      const { data } = await supabase.from('profiles').select('*').eq('id', user.id).single()
+      setProfile(data)
+    }
+    fetchProfile()
+  }, [])
+
+  return (
+    <div className="p-6 space-y-4">
+      <h1 className="text-2xl font-bold">Mon profil</h1>
+      {profile ? <pre>{JSON.stringify(profile, null, 2)}</pre> : <p>Chargement...</p>}
+    </div>
+  )
+}

--- a/src/app/dashboard/candidat/stats/page.tsx
+++ b/src/app/dashboard/candidat/stats/page.tsx
@@ -1,0 +1,28 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { createBrowserClient } from '@supabase/ssr'
+
+export default function StatsPage() {
+  const [stats, setStats] = useState<any | null>(null)
+  const supabase = createBrowserClient()
+
+  useEffect(() => {
+    async function fetchStats() {
+      const {
+        data: { user },
+      } = await supabase.auth.getUser()
+      if (!user) return
+      const { data } = await supabase.from('stats').select('*').eq('user_id', user.id).single()
+      setStats(data)
+    }
+    fetchStats()
+  }, [])
+
+  return (
+    <div className="p-6 space-y-4">
+      <h1 className="text-2xl font-bold">Mes stats</h1>
+      {stats ? <pre>{JSON.stringify(stats, null, 2)}</pre> : <p>Chargement...</p>}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add welcome dashboard with nav links
- implement candidate profile, offers, stats and invitations
- use Supabase client in each page to load user data

## Testing
- `pnpm format` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.15.2.tgz)*
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.15.2.tgz)*
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.15.2.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_6844e1ce94fc8324aad52073799504e4