### PR TITLE
Implement Supabase login form

### DIFF
--- a/src/app/login/LoginForm.tsx
+++ b/src/app/login/LoginForm.tsx
@@ -1,0 +1,84 @@
+"use client";
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { createBrowserClient } from "@/utils/supabase";
+
+export default function LoginForm() {
+  const supabase = createBrowserClient();
+  const router = useRouter();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [isSignUp, setIsSignUp] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    if (isSignUp) {
+      const { error } = await supabase.auth.signUp({ email, password });
+      if (error) return setError(error.message);
+    } else {
+      const { error } = await supabase.auth.signInWithPassword({ email, password });
+      if (error) return setError(error.message);
+    }
+    router.push("/dashboard/recruteur");
+  };
+
+  return (
+    <div>
+      <h1 className="text-2xl font-bold mb-4">
+        {isSignUp ? "Créer un compte" : "Se connecter"}
+      </h1>
+      <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+        <input
+          type="email"
+          placeholder="Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          required
+          className="border rounded-md p-2"
+        />
+        <input
+          type="password"
+          placeholder="Mot de passe"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          required
+          className="border rounded-md p-2"
+        />
+        {error && <p className="text-red-600 text-sm">{error}</p>}
+        <button
+          type="submit"
+          className="bg-green-600 text-white rounded-md py-2 hover:bg-green-700 transition"
+        >
+          {isSignUp ? "Créer le compte" : "Se connecter"}
+        </button>
+      </form>
+      <p className="text-sm mt-4">
+        {isSignUp ? (
+          <>
+            Déjà inscrit ?{' '}
+            <button
+              type="button"
+              onClick={() => setIsSignUp(false)}
+              className="text-green-600 hover:underline"
+            >
+              Se connecter
+            </button>
+          </>
+        ) : (
+          <>
+            Pas encore de compte ?{' '}
+            <button
+              type="button"
+              onClick={() => setIsSignUp(true)}
+              className="text-green-600 hover:underline"
+            >
+              S'inscrire
+            </button>
+          </>
+        )}
+      </p>
+    </div>
+  );
+}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,0 +1,17 @@
+import AuthButton from '@/components/AuthButton'
+import LoginForm from './LoginForm'
+
+export const metadata = {
+  title: 'Login',
+}
+
+export default function Page() {
+  return (
+    <div className="flex flex-col items-center py-10 px-4">
+      <AuthButton />
+      <div className="w-full max-w-md mt-8">
+        <LoginForm />
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- build a login page with sign-in and sign-up support
- redirect to recruiter dashboard on successful login
- show `AuthButton` on the login page for sign-out

## Testing
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.15.2.tgz)*
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.15.2.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_6844e1c8d1108324a891bb09166ad2b4