### PR TITLE
Add recruiter dashboard pages

### DIFF
--- a/src/app/dashboard/recruteur/abonnement/page.tsx
+++ b/src/app/dashboard/recruteur/abonnement/page.tsx
@@ -1,0 +1,8 @@
+export default function Abonnement() {
+  return (
+    <div className="p-6">
+      <h1 className="text-2xl font-bold mb-6">\uD83C\uDFAB Abonnement</h1>
+      <p>Fonctionnalité d'abonnement à venir.</p>
+    </div>
+  )
+}

--- a/src/app/dashboard/recruteur/alertes/page.tsx
+++ b/src/app/dashboard/recruteur/alertes/page.tsx
@@ -1,0 +1,8 @@
+export default function Alertes() {
+  return (
+    <div className="p-6">
+      <h1 className="text-2xl font-bold mb-6">\uD83D\uDD14 Alertes</h1>
+      <p>Gestion des alertes à venir.</p>
+    </div>
+  )
+}

--- a/src/app/dashboard/recruteur/offres/page.tsx
+++ b/src/app/dashboard/recruteur/offres/page.tsx
@@ -1,0 +1,45 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { createBrowserClient } from '@/utils/supabase'
+
+interface Offre {
+  id: string
+  titre: string
+  localisation: string
+}
+
+export default function ListeOffres() {
+  const [offres, setOffres] = useState<Offre[]>([])
+  const supabase = createBrowserClient()
+
+  useEffect(() => {
+    const load = async () => {
+      const { data, error } = await supabase
+        .from('offres')
+        .select('id, titre, localisation')
+
+      if (error) console.error('Erreur chargement offres', error)
+      else if (data) setOffres(data)
+    }
+    load()
+  }, [])
+
+  return (
+    <div className="p-6">
+      <h1 className="text-2xl font-bold mb-6">\uD83D\uDCCB Vos offres</h1>
+      {offres.length === 0 ? (
+        <p>Aucune offre disponible.</p>
+      ) : (
+        <ul className="space-y-2">
+          {offres.map((o) => (
+            <li key={o.id} className="border rounded-md p-4">
+              <p className="font-semibold">{o.titre}</p>
+              <p className="text-sm text-gray-500">{o.localisation}</p>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/src/app/dashboard/recruteur/page.tsx
+++ b/src/app/dashboard/recruteur/page.tsx
@@ -1,0 +1,15 @@
+import Link from 'next/link'
+
+export default function RecruteurDashboard() {
+  return (
+    <div className="p-6 space-y-4">
+      <h1 className="text-2xl font-bold mb-6">Tableau de bord recruteur</h1>
+      <nav className="flex flex-col gap-2">
+        <Link href="/dashboard/recruteur/offres" className="text-blue-600 hover:underline">Gérer les offres</Link>
+        <Link href="/dashboard/recruteur/shortlists" className="text-blue-600 hover:underline">Voir les shortlists</Link>
+        <Link href="/dashboard/recruteur/abonnement" className="text-blue-600 hover:underline">Mon abonnement</Link>
+        <Link href="/dashboard/recruteur/alertes" className="text-blue-600 hover:underline">Mes alertes</Link>
+      </nav>
+    </div>
+  )
+}

--- a/src/app/dashboard/recruteur/shortlists/[id]/page.tsx
+++ b/src/app/dashboard/recruteur/shortlists/[id]/page.tsx
@@ -1,0 +1,12 @@
+interface Params {
+  params: { id: string }
+}
+
+export default function ShortlistDetails({ params }: Params) {
+  return (
+    <div className="p-6">
+      <h1 className="text-2xl font-bold mb-4">Détail de la shortlist {params.id}</h1>
+      <p>Contenu de la shortlist à venir.</p>
+    </div>
+  )
+}

--- a/src/app/dashboard/recruteur/shortlists/page.tsx
+++ b/src/app/dashboard/recruteur/shortlists/page.tsx
@@ -1,0 +1,46 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import Link from 'next/link'
+import { createBrowserClient } from '@/utils/supabase'
+
+interface Shortlist {
+  id: string
+  titre: string
+}
+
+export default function ListeShortlists() {
+  const [shortlists, setShortlists] = useState<Shortlist[]>([])
+  const supabase = createBrowserClient()
+
+  useEffect(() => {
+    const load = async () => {
+      const { data, error } = await supabase
+        .from('shortlists')
+        .select('id, titre')
+
+      if (error) console.error('Erreur chargement shortlists', error)
+      else if (data) setShortlists(data)
+    }
+    load()
+  }, [])
+
+  return (
+    <div className="p-6">
+      <h1 className="text-2xl font-bold mb-6">\u2B50 Vos shortlists</h1>
+      {shortlists.length === 0 ? (
+        <p>Aucune shortlist enregistrée.</p>
+      ) : (
+        <ul className="space-y-2">
+          {shortlists.map((s) => (
+            <li key={s.id} className="border rounded-md p-4">
+              <Link href={`/dashboard/recruteur/shortlists/${s.id}`} className="font-semibold text-blue-600 hover:underline">
+                {s.titre}
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -10,7 +10,7 @@ export default function Navbar() {
       </Link>
       <nav className="space-x-6 text-sm">
         <Link href="/rendez-vous" className="hover:text-green-600">Prendre rendez-vous</Link>
-        <Link href="/dashboard" className="bg-green-600 text-white px-4 py-2 rounded-md hover:bg-green-700 transition">
+        <Link href="/dashboard/recruteur" className="bg-green-600 text-white px-4 py-2 rounded-md hover:bg-green-700 transition">
           Se connecter
         </Link>
       </nav>


### PR DESCRIPTION
## Summary
- add pages to show recruiter offers, shortlists, subscription, and alerts
- add recruiter dashboard index linking to all pages
- update Navbar link to go to dashboard index
- provide placeholder for shortlist details

## Testing
- `pnpm test` *(fails: Error when performing request to https://registry.npmjs.org/... )*

------
https://chatgpt.com/codex/tasks/task_e_6844e1c505d483248ff7f5ce4075be7d