### PR TITLE
Fix testimonials quote escaping

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -109,7 +109,7 @@ export default function HomePage() {
             { name: 'Fatou', text: 'Un service client réactif et professionnel, je recommande.' },
           ].map((t) => (
             <div key={t.name} className="bg-white p-6 rounded-md shadow">
-              <p className="italic mb-2">"{t.text}"</p>
+              <p className="italic mb-2">&quot;{t.text}&quot;</p>
               <p className="font-semibold text-green-700">{t.name}</p>
             </div>
           ))}


### PR DESCRIPTION
## Summary
- escape quotes in home page testimonials

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6844f210a4e883248d2607e1905ffbfa