### PR TITLE
Fix Supabase dependency warning

### DIFF
--- a/src/app/dashboard/recruteur/candidats/page.tsx
+++ b/src/app/dashboard/recruteur/candidats/page.tsx
@@ -13,9 +13,9 @@ type Candidat = {
 
 export default function ListeCandidats() {
   const [candidats, setCandidats] = useState<Candidat[]>([]);
-  const supabase = createBrowserClient();
 
   useEffect(() => {
+    const supabase = createBrowserClient();
     async function fetchCandidats() {
       const { data, error } = await supabase
         .from('candidats')


### PR DESCRIPTION
## Summary
- initialize Supabase inside the useEffect hook on the candidate list page

## Testing
- `pnpm lint` *(fails: react/no-unescaped-entities in src/app/page.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_6844f215009083249e9fcb5fdc9186db