### PR TITLE
Fix duplicate import in layout

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,7 +2,6 @@ import '../globals.css'; // Corrigé : remonter d'un dossier
 import { ReactNode } from 'react';
 import Navbar from '../components/Navbar'; // Chemin relatif depuis /app
 import Footer from '../components/Footer'; // Idem
-import '../globals.css';
 
 
 export const metadata = {


### PR DESCRIPTION
## Summary
- remove redundant `globals.css` import from `layout.tsx`

## Testing
- `pnpm lint` *(fails: react/no-unescaped-entities, missing dependency)*
- `pnpm type-check` *(fails: Expected 2-3 arguments, but got 0)*
- `pnpm format-check` *(fails: code style issues found in 7 files)*
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6844f219c53c8324aedab66ee08903b7