### PR TITLE
Add session check for recruiter routes

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -9,7 +9,14 @@ export async function middleware(request: NextRequest) {
 
     // Refresh session if expired - required for Server Components
     // https://supabase.com/docs/guides/auth/auth-helpers/nextjs#managing-session-with-middleware
-    await supabase.auth.getSession()
+    const {
+      data: { session },
+    } = await supabase.auth.getSession()
+
+    if (!session && request.nextUrl.pathname.startsWith('/dashboard/recruteur')) {
+      const redirectUrl = new URL('/login', request.url)
+      return NextResponse.redirect(redirectUrl)
+    }
 
     return response
   } catch (e) {


### PR DESCRIPTION
## Summary
- redirect `/dashboard/recruteur` visitors to `/login` when no Supabase session exists

## Testing
- `pnpm lint` *(fails: next not found)*
- `pnpm type-check` *(fails: missing type definitions)*
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844f973a888832498a5c879fd2ec401