### PR TITLE
Add candidats listing with filters

### DIFF
--- a/src/app/candidats/[id]/page.tsx
+++ b/src/app/candidats/[id]/page.tsx
@@ -1,0 +1,90 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useParams } from 'next/navigation'
+import Link from 'next/link'
+import { createBrowserClient } from '@/utils/supabase'
+
+interface Candidat {
+  id: string
+  nom: string
+  prenom: string
+  ville: string
+  titre_professionnel: string
+  email?: string | null
+  telephone?: string | null
+  linkedin?: string | null
+}
+
+export default function CandidatPage() {
+  const params = useParams()
+  const supabase = createBrowserClient()
+  const [candidat, setCandidat] = useState<Candidat | null>(null)
+
+  useEffect(() => {
+    const fetchCandidat = async () => {
+      const { data, error } = await supabase
+        .from('candidats')
+        .select(
+          'id, nom, prenom, ville, titre_professionnel, email, telephone, linkedin',
+        )
+        .eq('id', params.id as string)
+        .single()
+
+      if (!error) setCandidat(data)
+    }
+
+    if (params.id) {
+      fetchCandidat()
+    }
+  }, [params.id, supabase])
+
+  if (!candidat) {
+    return <p className="p-6">Chargement...</p>
+  }
+
+  return (
+    <div className="space-y-4 p-6">
+      <Link href="/candidats" className="text-blue-600 hover:underline">
+        &larr; Retour à la liste
+      </Link>
+
+      <div>
+        <h1 className="text-2xl font-bold">
+          {candidat.prenom} {candidat.nom}
+        </h1>
+        <p className="text-gray-600">{candidat.titre_professionnel}</p>
+        <p className="text-sm text-gray-500">📍 {candidat.ville}</p>
+      </div>
+
+      <div className="space-y-2">
+        {candidat.email && (
+          <a
+            href={`mailto:${candidat.email}`}
+            className="block text-blue-600 hover:underline"
+          >
+            Contacter par email
+          </a>
+        )}
+        {candidat.telephone && (
+          <a
+            href={`tel:${candidat.telephone}`}
+            className="block text-blue-600 hover:underline"
+          >
+            Appeler
+          </a>
+        )}
+        {candidat.linkedin && (
+          <a
+            href={candidat.linkedin}
+            target="_blank"
+            rel="noreferrer"
+            className="block text-blue-600 hover:underline"
+          >
+            Profil LinkedIn
+          </a>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/app/candidats/page.tsx
+++ b/src/app/candidats/page.tsx
@@ -1,0 +1,110 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import Link from 'next/link'
+import { createBrowserClient } from '@/utils/supabase'
+
+interface Candidat {
+  id: string
+  nom: string
+  prenom: string
+  ville: string
+  genre?: string | null
+  age?: number | null
+  titre_professionnel: string
+}
+
+export default function CandidatsPage() {
+  const supabase = createBrowserClient()
+  const [candidats, setCandidats] = useState<Candidat[]>([])
+  const [keyword, setKeyword] = useState('')
+  const [ville, setVille] = useState('')
+  const [genre, setGenre] = useState('')
+  const [age, setAge] = useState('')
+
+  const fetchCandidats = async () => {
+    let query = supabase
+      .from('candidats')
+      .select('id, nom, prenom, ville, genre, age, titre_professionnel')
+
+    if (keyword) {
+      query = query.or(
+        `nom.ilike.%${keyword}%,prenom.ilike.%${keyword}%,titre_professionnel.ilike.%${keyword}%`,
+      )
+    }
+    if (ville) query = query.eq('ville', ville)
+    if (genre) query = query.eq('genre', genre)
+    if (age) query = query.eq('age', Number(age))
+
+    const { data, error } = await query
+    if (error) console.error('Erreur chargement candidats', error)
+    else setCandidats(data || [])
+  }
+
+  useEffect(() => {
+    fetchCandidats()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [keyword, ville, genre, age])
+
+  return (
+    <div className="p-6">
+      <h1 className="mb-4 text-2xl font-bold">Tous les candidats</h1>
+      <div className="mb-6 grid grid-cols-1 gap-4 md:grid-cols-4">
+        <input
+          type="text"
+          placeholder="Mot-clé"
+          value={keyword}
+          onChange={(e) => setKeyword(e.target.value)}
+          className="rounded border px-3 py-2"
+        />
+        <input
+          type="text"
+          placeholder="Ville"
+          value={ville}
+          onChange={(e) => setVille(e.target.value)}
+          className="rounded border px-3 py-2"
+        />
+        <select
+          value={genre}
+          onChange={(e) => setGenre(e.target.value)}
+          className="rounded border px-3 py-2"
+        >
+          <option value="">Genre</option>
+          <option value="M">Homme</option>
+          <option value="F">Femme</option>
+        </select>
+        <input
+          type="number"
+          placeholder="Âge"
+          value={age}
+          onChange={(e) => setAge(e.target.value)}
+          className="rounded border px-3 py-2"
+        />
+      </div>
+      {candidats.length === 0 ? (
+        <p>Aucun candidat trouvé.</p>
+      ) : (
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+          {candidats.map((candidat) => (
+            <div
+              key={candidat.id}
+              className="rounded-md border bg-white p-4 shadow-sm"
+            >
+              <h2 className="text-xl font-semibold">
+                {candidat.prenom} {candidat.nom}
+              </h2>
+              <p className="text-gray-600">{candidat.titre_professionnel}</p>
+              <p className="text-sm text-gray-500">📍 {candidat.ville}</p>
+              <Link
+                href={`/candidats/${candidat.id}`}
+                className="mt-2 inline-block text-blue-600 hover:underline"
+              >
+                Voir la fiche →
+              </Link>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- create `/candidats` route to list profiles
- add filtering controls
- create individual candidate page under `/candidats/[id]`

## Testing
- `pnpm lint` *(fails: react/no-unescaped-entities in existing files)*
- `pnpm type-check`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6844f96f61308324be7506bc5ca4a930