### PR TITLE
Protect candidate dashboard

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -13,7 +13,11 @@ export async function middleware(request: NextRequest) {
       data: { session },
     } = await supabase.auth.getSession()
 
-    if (!session && request.nextUrl.pathname.startsWith('/dashboard/recruteur')) {
+    if (
+      !session &&
+      (request.nextUrl.pathname.startsWith('/dashboard/recruteur') ||
+        request.nextUrl.pathname.startsWith('/dashboard/candidat'))
+    ) {
       const redirectUrl = new URL('/login', request.url)
       return NextResponse.redirect(redirectUrl)
     }


### PR DESCRIPTION
## Summary
- protect candidate dashboard by ensuring `/dashboard/candidat` requires a valid session

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_684597b33a1c83249061be26e7f7d9a6